### PR TITLE
Expose an option to wrap cronjobs in flock(1)

### DIFF
--- a/jobs/cron/spec
+++ b/jobs/cron/spec
@@ -32,8 +32,11 @@ properties:
       If script is specified, the contents of that key are written out to disk and executed by cron.
 
       If command and script are specified for the same entry, the contents of script will be executed, and command ignored
+
+      If lock is specified, the cronjob will be wrapped by flock(1) -n ensuring only one instance runs at a time.
     example:
     - command: /var/vcap/packages/mypackage/bin/myhourlyscript
+      lock: /var/vcap/sys/run/cron/myhourly.lock
       script:
         name: touch.sh
         contents: |

--- a/jobs/cron/templates/bin/setup_crontab.erb
+++ b/jobs/cron/templates/bin/setup_crontab.erb
@@ -24,6 +24,10 @@ chmod 755 ${ENTRY}
 ENTRY="<%= entry["command"].gsub(/([^\\])%/, '\1\%') %>"
 <% end %>
 
+<% if entry.key?("lock") %>
+ENTRY="/usr/bin/flock -n <%= entry['lock'] %> ${ENTRY}"
+<% end %>
+
 CRONTAB="${CRONTAB}\n<%= entry["minute"] %> <%= entry["hour"] %> <%= entry["day"] %> <%= entry["month"] %> <%= entry["wday"] %> <%= entry["user"] %> ${ENTRY}"
 <% end %>
 


### PR DESCRIPTION
This PR adds a new optional key for entries: `lock`.   If provided, the cronjob will be wrapped in a `flock -n :lock:` to prevent multiple copies of the cronjob (or different cronjobs using the same lock file) from running at the same time.

WDYT?


