### PR TITLE
Allow per-entry environment variables.

### DIFF
--- a/jobs/cron/spec
+++ b/jobs/cron/spec
@@ -34,6 +34,8 @@ properties:
       If command and script are specified for the same entry, the contents of script will be executed, and command ignored
 
       If lock is specified, the cronjob will be wrapped by flock(1) -n ensuring only one instance runs at a time.
+
+      If a hash of variables is specified, the cronjob will run with those environment variables.
     example:
     - command: /var/vcap/packages/mypackage/bin/myhourlyscript
       lock: /var/vcap/sys/run/cron/myhourly.lock

--- a/jobs/cron/templates/bin/setup_crontab.erb
+++ b/jobs/cron/templates/bin/setup_crontab.erb
@@ -28,7 +28,11 @@ ENTRY="<%= entry["command"].gsub(/([^\\])%/, '\1\%') %>"
 ENTRY="/usr/bin/flock -n <%= entry['lock'] %> ${ENTRY}"
 <% end %>
 
-CRONTAB="${CRONTAB}\n<%= entry["minute"] %> <%= entry["hour"] %> <%= entry["day"] %> <%= entry["month"] %> <%= entry["wday"] %> <%= entry["user"] %> ${ENTRY}"
+<%
+  entry_vars = entry.fetch("variables", {}).map { |k, v| "#{k}=#{v}" }.join(" ")
+%>
+
+CRONTAB="${CRONTAB}\n<%= entry["minute"] %> <%= entry["hour"] %> <%= entry["day"] %> <%= entry["month"] %> <%= entry["wday"] %> <%= entry["user"] %> <%= entry_vars %> ${ENTRY}"
 <% end %>
 
 echo -e "$CRONTAB" > /etc/cron.d/cron-boshrelease-crontab


### PR DESCRIPTION
So that we can scope environment variables to specific cron entries.

h/t @cnelson 