### PR TITLE
Set value to empty string

### DIFF
--- a/jobs/cron/templates/bin/setup_crontab.erb
+++ b/jobs/cron/templates/bin/setup_crontab.erb
@@ -9,7 +9,7 @@ rm -f ${CONFIG_DIR}/*
 
 read -r -d '' CRONTAB <<'EOF'
 <% p("cron.variables", {}).each do |k, v| %>
-<%= k %>=<%= v || '' %>
+<%= k %>=<%= v || "''" %>
 <% end %>
 EOF
 

--- a/jobs/cron/templates/bin/setup_crontab.erb
+++ b/jobs/cron/templates/bin/setup_crontab.erb
@@ -9,7 +9,7 @@ rm -f ${CONFIG_DIR}/*
 
 read -r -d '' CRONTAB <<'EOF'
 <% p("cron.variables", {}).each do |k, v| %>
-<%= k %>=<%= v %>
+<%= k %>=<%= v || '' %>
 <% end %>
 EOF
 


### PR DESCRIPTION
This sets variable in value to an empty string when a key is provided, but a value is nil.  This prevents parsing errors from occuring within a `crontab`.