### PR TITLE
check for empty strings rather than falsiness

### DIFF
--- a/jobs/cron/templates/bin/setup_crontab.erb
+++ b/jobs/cron/templates/bin/setup_crontab.erb
@@ -9,7 +9,7 @@ rm -f ${CONFIG_DIR}/*
 
 read -r -d '' CRONTAB <<'EOF'
 <% p("cron.variables", {}).each do |k, v| %>
-<%= k %>=<%= v || "''" %>
+<%= k %>=<%= v.empty? ? "''" : v %>
 <% end %>
 EOF
 


### PR DESCRIPTION
This fixes two potential problems with the current behavior:
- currently, if you were to set `cron.variables.foo = 0`, `0` would be replaced with `''`
- currently, if `cron.variables.foo = ''`, the empty string is not replaced with `''`, which was the intent behind #8 